### PR TITLE
Remove video_screenshot_url DB and schema

### DIFF
--- a/app/models/artist_page.rb
+++ b/app/models/artist_page.rb
@@ -16,7 +16,6 @@
 #  stripe_user_id       :string
 #  twitter_handle       :string
 #  updated_at           :datetime         not null
-#  video_screenshot_url :string
 #  video_url            :string
 #
 

--- a/app/views/artist_pages/show.json.jbuilder
+++ b/app/views/artist_pages/show.json.jbuilder
@@ -2,7 +2,6 @@ json.id @artist_page.id
 json.name @artist_page.name
 json.location @artist_page.location
 json.accent_color @artist_page.accent_color
-json.video_screenshot_url @artist_page.video_screenshot_url
 json.video_url @artist_page.video_url
 json.twitter_handle @artist_page.twitter_handle
 json.instagram_handle @artist_page.instagram_handle

--- a/client/src/redux/artists/initial-state.ts
+++ b/client/src/redux/artists/initial-state.ts
@@ -3,7 +3,6 @@ export interface ArtistModel {
   id: number;
   accent_color: string;
   video_url: string;
-  video_screenshot_url: string;
   location: string;
   twitter_handle: string;
   instagram_handle: string;

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,7 +26,6 @@ ActiveRecord::Schema.define(version: 2019_08_05_012523) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "video_url"
-    t.string "video_screenshot_url"
     t.string "state_token"
     t.string "stripe_user_id"
     t.string "stripe_access_token"

--- a/lib/tasks/dummy.rake
+++ b/lib/tasks/dummy.rake
@@ -27,7 +27,6 @@ namespace :dummy do
         location: Faker::GameOfThrones.city,
         twitter_handle: Faker::Twitter.screen_name,
         instagram_handle: Faker::Twitter.screen_name,
-        video_screenshot_url: "https://dummyimage.com/400x225/#{Faker::Color.hex_color[1..-1]}/fff",
         video_url: "https://www.youtube.com/watch?v=4nsKDJlpUbA",
         bio: Faker::Dune.quote,
         accent_color: Faker::Color.hex_color

--- a/spec/factories/artist_page.rb
+++ b/spec/factories/artist_page.rb
@@ -16,7 +16,6 @@
 #  stripe_user_id       :string
 #  twitter_handle       :string
 #  updated_at           :datetime         not null
-#  video_screenshot_url :string
 #  video_url            :string
 #
 


### PR DESCRIPTION
Just removed it from everywhere. We don't use it anymore. 
