### PR TITLE
WIP: Cache artist response json

### DIFF
--- a/app/views/artist_pages/show.json.jbuilder
+++ b/app/views/artist_pages/show.json.jbuilder
@@ -1,23 +1,25 @@
-json.id @artist_page.id
-json.name @artist_page.name
-json.slug @artist_page.slug
-json.location @artist_page.location
-json.accent_color @artist_page.accent_color
-json.video_url @artist_page.video_url
-json.twitter_handle @artist_page.twitter_handle
-json.instagram_handle @artist_page.instagram_handle
-json.images @artist_page.images.map(&:url)
+json.cache! [@artist_page], expires_in: 10.seconds do
+  json.id @artist_page.id
+  json.name @artist_page.name
+  json.slug @artist_page.slug
+  json.location @artist_page.location
+  json.accent_color @artist_page.accent_color
+  json.video_url @artist_page.video_url
+  json.twitter_handle @artist_page.twitter_handle
+  json.instagram_handle @artist_page.instagram_handle
+  json.images @artist_page.images.map(&:url)
 
-json.most_recent_supporter do
-  if @artist_page.most_recent_supporter.present?
-    json.partial! "users/user", user: @artist_page.most_recent_supporter
-  else
-    json.null!
+  json.most_recent_supporter do
+    if @artist_page.most_recent_supporter.present?
+      json.partial! "users/user", user: @artist_page.most_recent_supporter
+    else
+      json.null!
+    end
   end
+
+  json.owners @artist_page.owners, partial: "users/user", as: :user
+
+  json.supporters @artist_page.active_subscribers, partial: "users/user", as: :user
+
+  json.posts @artist_page.posts, partial: "posts/post", as: :post
 end
-
-json.owners @artist_page.owners, partial: "users/user", as: :user
-
-json.supporters @artist_page.active_subscribers, partial: "users/user", as: :user
-
-json.posts @artist_page.posts, partial: "posts/post", as: :post


### PR DESCRIPTION
One idea for helping performance - this is one of the most expensive operations since we're querying across multiple models, etc. We could cache this for a very short period of time to make sure we only have to do these calls once.

The big issue I see is that we're relying on this to determine whether a user is subscribed - e.g. this would need to change immediately after a user subscribes so that the page changes for them immediately.

A possible solution would be to move subscriptions into the `/me` response.