### PR TITLE
PROD: Add .approved scope to ArtistPage, to facilitate loading approved pages only.

### DIFF
--- a/app/models/artist_page.rb
+++ b/app/models/artist_page.rb
@@ -47,6 +47,8 @@ class ArtistPage < ApplicationRecord
 
   before_save :check_approved
 
+  scope :approved, -> { where(approved: true) }
+
   def sluggy_slug
     return unless slug
 

--- a/spec/models/artist_page_spec.rb
+++ b/spec/models/artist_page_spec.rb
@@ -1,6 +1,19 @@
 require "rails_helper"
 
 RSpec.describe ArtistPage, type: :model do
+  describe ".approved scope" do
+    let!(:approved_page) { create(:artist_page, approved: true) }
+    let!(:unapproved_page) { create(:artist_page, approved: false) }
+
+    it "returns approved artist pages" do
+      expect(ArtistPage.approved).to eq([approved_page])
+    end
+
+    it "does not return not approved artist pages" do
+      expect(ArtistPage.approved).to_not include(unapproved_page)
+    end
+  end
+
   describe "#monthly_total" do
     context "with active subscriptions" do
       it "returns the montly total" do


### PR DESCRIPTION
`release`-side PR counterpart for https://github.com/ampled-music/ampled-web/pull/452

Contains no functional changes, only helper code.

