### PR TITLE
DEV: Add release-phase command to run migrations to Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,7 @@
 web:     bundle exec puma -C config/puma.rb
 worker:  bundle exec sidekiq
+
+# Commands for Heroku's "release" phase. These get run after the app is built, but
+# before the new app version is deployed to users. For details, see:
+# https://devcenter.heroku.com/articles/release-phase
+release: bundle exec rake db:migrate

--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ Generated with [Raygun](https://github.com/carbonfive/raygun).
     - [Using ChromeDriver](#using-chromedriver)
     - [Continuous Integration/Deployment with CircleCI and Heroku](#continuous-integrationdeployment-with-circleci-and-heroku)
 - [Deploy to Acceptance/Production](#deploy-to-acceptanceproduction)
+- [Database migrations and rollbacks](#database-migrations-and-rollbacks)
 - [Server Environments](#server-environments)
-  - [Hosting](#hosting)
-  - [Environment Variables](#environment-variables)
-  - [Third Party Services](#third-party-services)
+    - [Hosting](#hosting)
+    - [Environment Variables](#environment-variables)
+    - [Third Party Services](#third-party-services)
+    - [Using the Stripe CLI to test webhooks locally](#using-the-stripe-cli-to-test-webhooks-locally)
 - [Internal Tools](#internal-tools)
   - [`application-fee-management`](#application-fee-management)
     - [Installation & setup](#installation--setup)
@@ -155,9 +157,27 @@ On successful builds, Heroku will trigger a deployment via its
 # Deploy to Acceptance/Production
 
 1. Pull Request into Acceptance/Production and run merge will trigger CI
-2. If there are pending migrations, run them locally with the appropriate `DATABASE_URL`
-   - ie: `DATABASE_URL=postgres://ACCEPTANCE/PRODUCTION_URL rails db:migrate`
-3. Trigger a restart in Heroku
+
+The release process on Heroku will automatically run database migrations after the new
+app version is built, but before it is deployed to users. This is controlled via the `release`
+command in our app's [Procfile](Procfile).
+
+# Database migrations and rollbacks
+
+Database migrations run automagically ✨ in staging and production as part of the deploy process.
+If you ever need to run a migration or a migration rollback in a Heroku environment, you can
+do so using the `heroku run` command (part of the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)), like this:
+```bash
+$ heroku run rake db:migrate --app ampled-web
+```
+
+Or, for example, to roll back the most recent migration:
+```bash
+$ heroku run rake db:rollback --app ampled-web
+```
+
+(replace the app name above with `ampled-web-production` if you need to run this against production)
+
 
 # Server Environments
 


### PR DESCRIPTION
This PR adds a release command to our Procfile to run all database migrations during a Heroku deploy. This will guarantee that after each deploy the code and database state are in sync.