### PR TITLE
Remove unused stripe_access_token column from artist_pages table

### DIFF
--- a/app/models/artist_page.rb
+++ b/app/models/artist_page.rb
@@ -17,7 +17,6 @@
 #  name                 :string
 #  slug                 :string
 #  state_token          :string
-#  stripe_access_token  :string
 #  stripe_product_id    :string
 #  stripe_user_id       :string
 #  style_type           :string

--- a/db/migrate/20200822212821_remove_stripe_access_token_from_artist_page.rb
+++ b/db/migrate/20200822212821_remove_stripe_access_token_from_artist_page.rb
@@ -1,0 +1,14 @@
+class RemoveStripeAccessTokenFromArtistPage < ActiveRecord::Migration[5.2]
+  def up
+    # Only perform the migration if all records have this field unset, as a safeguard.
+    artist_pages_with_stripe_access_token_count = ArtistPage.where.not(stripe_access_token: nil).count
+    if artist_pages_with_stripe_access_token_count > 0
+      raise "Found #{artist_pages_with_stripe_access_token_count} Artist Pages with a Stripe token. Won't migrate."
+    end
+    remove_column :artist_pages, :stripe_access_token
+  end
+
+  def down
+    add_column :artist_pages, :stripe_access_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_195516) do
+ActiveRecord::Schema.define(version: 2020_08_22_212821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,7 +29,6 @@ ActiveRecord::Schema.define(version: 2020_08_19_195516) do
     t.string "video_screenshot_url"
     t.string "state_token"
     t.string "stripe_user_id"
-    t.string "stripe_access_token"
     t.string "stripe_product_id"
     t.string "slug"
     t.boolean "verb_plural", default: false


### PR DESCRIPTION
In the course of discussing https://ampled.slack.com/archives/GPMJ9RCMD/p1598044895026800 I realized that this column is empty in prod and is never used anywhere in the code, so I propose we remove it so that we don't have to wonder about it in the future.