### PR TITLE
[603] (fix)choose second number in random sum, otherwise it's 1 most of the time

### DIFF
--- a/client/src/containers/user-details/UserImage.tsx
+++ b/client/src/containers/user-details/UserImage.tsx
@@ -32,7 +32,7 @@ class UserImage extends React.Component<Props, any> {
         const plus = acc + n;
         const asArr = plus.toString().split('');
         if (asArr.length === 1) return plus;
-        else return Number(asArr[0]);
+        else return Number(asArr[1]);
       }, 0);
     return num;
   }


### PR DESCRIPTION
In order to randomly choose an avatar image that is consistent based on username (so it persists across the app/on reload) I wrote a "random" number generator based on the first character of a username. A bug caused it to be 1 or 2 most of the time and the images didn't actually appear random.

This small change should fix it (basically it sums digits in a char code, but to choose a single digit if they summed to more than 9 I was picking the first number in the sum, which is probably 1 or 2 as the sum was usually less than 30).

Trello: - https://trello.com/c/zE4yxMJF/603-default-avatar-images-if-you-havent-uploaded-a-photo
