### PR TITLE
bump CodeCov gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -776,10 +776,9 @@ GEM
     cloudinary (1.9.1)
       aws_cf_signer
       rest-client
-    codecov (0.1.14)
+    codecov (0.2.11)
       json
       simplecov
-      url
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -806,7 +805,7 @@ GEM
       devise (~> 4.0)
       warden-jwt_auth (~> 0.3.5)
     diff-lcs (1.3)
-    docile (1.3.1)
+    docile (1.3.2)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.5.0)
@@ -850,7 +849,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.1.0)
+    json (2.3.1)
     jwt (2.1.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -1042,11 +1041,10 @@ GEM
     simple_form (4.0.1)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
-    simplecov (0.16.1)
+    simplecov (0.19.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     skylight (3.1.2)
       skylight-core (= 3.1.2)
     skylight-core (3.1.2)
@@ -1090,7 +1088,6 @@ GEM
     unf_ext (0.0.7.5)
     unicode-display_width (1.7.0)
     uniform_notifier (1.13.0)
-    url (0.3.2)
     vcr (4.0.0)
     warden (1.2.7)
       rack (>= 1.0)


### PR DESCRIPTION
On August 17, 2020 CodeCov removed all versions of their Ruby gem before `0.2.0` from public use (more details at the [top of their readme](https://github.com/codecov/codecov-ruby)). We were using `0.1.14`. Because there is no public copy of that version of the gem, `bundle install` fails if the gem is not already installed. This bumps the gem to the latest version, `0.2.11`.

If you are curious, here is the [diff between the versions](https://github.com/codecov/codecov-ruby/compare/v0.1.14...v0.2.11).

The CodeCov PR check is working, so I assume there are no issues with the bump?