### PR TITLE
fix dummy user data generation

### DIFF
--- a/lib/tasks/dummy.rake
+++ b/lib/tasks/dummy.rake
@@ -31,7 +31,7 @@ namespace :dummy do
     }
 
     users.each do |us|
-      us.image << Image.create(url: image_url.call, public_id: public_id.call)
+      us.image = Image.create(url: image_url.call, public_id: public_id.call)
     end
   end
 


### PR DESCRIPTION
While trying to get everything running I noticed that the dummy user generation task was broken. It raised an error because it was trying to append to a "has one" image relation on User. This updates the call to use the standard setter.
