### PR TITLE
(644) Add ability for backend and frontend to switch between Cloudinary "clouds"

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,3 +10,8 @@ PUMA_THREADS=5
 
 S3_BUCKET=ampled-test
 DEVISE_JWT_SECRET_KEY=seekret-local-key
+
+# Cloudinary configuration. Get key / secret from acceptance environment.
+CLOUDINARY_CLOUD_NAME=ampledacceptance
+# CLOUDINARY_API_KEY=
+# CLOUDINARY_API_SECRET=

--- a/app/services/social_images/social_image.rb
+++ b/app/services/social_images/social_image.rb
@@ -1,6 +1,6 @@
 module SocialImages
   class SocialImage
-    BASE_UPLOAD_URL = "https://res.cloudinary.com/ampled-web/image/upload"
+    BASE_UPLOAD_URL = "https://res.cloudinary.com/#{Cloudinary.config.cloud_name}/image/upload"
 
     def self.build(artist_page)
       new(artist_page).build

--- a/client/.env.sample
+++ b/client/.env.sample
@@ -1,3 +1,5 @@
 # Environment variables used by client-side code.
 
 REACT_APP_STRIPE_API_KEY=
+
+REACT_APP_CLOUDINARY_CLOUD_NAME=ampledacceptance

--- a/client/src/api/cloudinary/delete-image.ts
+++ b/client/src/api/cloudinary/delete-image.ts
@@ -5,7 +5,7 @@ export const deleteFileFromCloudinary = async (deleteToken: string) => {
   try {
     await axios({
       method: 'post',
-      url: config.cloudinary.deleteImageUrl,
+      url: `https://api.cloudinary.com/v1_1/${config.cloudinary.cloud_name}/delete_by_token`,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/client/src/api/cloudinary/upload-image.ts
+++ b/client/src/api/cloudinary/upload-image.ts
@@ -22,8 +22,11 @@ export const uploadFileToCloudinary = async (file: any) => {
   };
 
   try {
+    console.log("Trying to upload to: ", `https://api.cloudinary.com/v1_1/${config.cloudinary.cloud_name}/upload`)
+    console.log("Config: ", config)
+
     const { data } = await axios.post(
-      config.cloudinary.uploadImageUrl,
+      `https://api.cloudinary.com/v1_1/${config.cloudinary.cloud_name}/upload`,
       formData,
       reqConfig,
     );

--- a/client/src/config/index.ts
+++ b/client/src/config/index.ts
@@ -12,9 +12,7 @@ export const config = {
     about: process.env.REACT_APP_URL_ABOUT || '/page/about-us',
   },
   cloudinary: {
-    uploadImageUrl: 'https://api.cloudinary.com/v1_1/ampled-web/upload',
-    deleteImageUrl:
-      'https://api.cloudinary.com/v1_1/ampled-web/delete_by_token',
+    cloud_name: process.env.REACT_APP_CLOUDINARY_CLOUD_NAME || 'ampled-web',
     apiKey: process.env.REACT_APP_CLOUDINARY_API_KEY,
     apiSecret: process.env.REACT_APP_CLOUDINARY_API_SECRET,
   },

--- a/client/src/containers/ProtectedRoute.tsx
+++ b/client/src/containers/ProtectedRoute.tsx
@@ -61,7 +61,7 @@ const ProtectedRoute = ({
     return (
       <div className="public-routes">
         <div>
-          <CloudinaryContext cloudName="ampled-web">
+          <CloudinaryContext cloudName={config.cloudinary.cloud_name}>
             <Nav match={props.match} history={props.history} />
             <main>
               {isLoggedIn ? (

--- a/client/src/containers/PublicRoute.tsx
+++ b/client/src/containers/PublicRoute.tsx
@@ -3,6 +3,7 @@ import { Route } from 'react-router-dom';
 import { CloudinaryContext } from 'cloudinary-react';
 import { Nav } from './shared/nav/Nav';
 import { Footer } from './shared/footer/Footer';
+import { config } from '../config';
 
 export const PublicRoute = ({ component: Component, ...rest }) => {
   const randomColor = () => {
@@ -21,7 +22,7 @@ export const PublicRoute = ({ component: Component, ...rest }) => {
     return (
       <div className="public-routes">
         <div>
-          <CloudinaryContext cloudName="ampled-web">
+          <CloudinaryContext cloudName={config.cloudinary.cloud_name}>
             <Nav match={props.match} history={props.history} />
             <main>
               <Component {...props} />

--- a/client/src/containers/artist/posts/post/Post.tsx
+++ b/client/src/containers/artist/posts/post/Post.tsx
@@ -36,7 +36,7 @@ const renderCloudinaryPhoto = (image: string) => {
       const img_src = image.replace('upload/', `upload/`);
       return img_src;
     } else {
-      const img_src = `https://res.cloudinary.com/ampled-web/image/fetch/${image}`;
+      const img_src = `https://res.cloudinary.com/${config.cloudinary.cloud_name}/image/fetch/${image}`;
       return img_src;
     }
   }

--- a/config/initializers/cloudinary.rb
+++ b/config/initializers/cloudinary.rb
@@ -1,0 +1,6 @@
+Cloudinary.config do |config|
+  config.cloud_name = ENV["CLOUDINARY_CLOUD_NAME"] || 'ampled-web'
+  config.api_key = ENV["CLOUDINARY_API_KEY"]
+  config.api_secret = ENV["CLOUDINARY_API_SECRET"]
+  config.secure = true
+end


### PR DESCRIPTION
As part of separating production and acceptance into two Cloudinary accounts, we need the capability to switch the "cloudinary cloud" in our code, since the cloud for acceptance is called something different than the production one.

In this PR I also took the opportunity to configure Cloudinary in the backend, so that the backend perform cloudinary operations.

Trello: - https://trello.com/c/a9XFUA9f/664-delete-all-unused-images-from-cloudinary
