### PR TITLE
Add Rake task to soft-delete unused images from Cloudinary

### DIFF
--- a/lib/tasks/images.rake
+++ b/lib/tasks/images.rake
@@ -1,0 +1,50 @@
+namespace :images do
+
+  # Folder into which we place images that are meant to be soft-deleted.
+  # The public_id of the image is preserved, so that the deletion can be undone by
+  # moving the image out of the folder into the Cloudinary root.
+  SOFT_DELETE_FOLDER = "soft_deleted"
+
+  desc "Soft-deletes images that aren't referenced by the database."
+  task soft_delete_unused: [:environment] do
+    next_cursor = nil
+    while true do
+      results = Cloudinary::Api.resources(type: "upload", next_cursor: next_cursor)
+      next_cursor = results.fetch("next_cursor", nil)
+      resources = results["resources"]
+      Rails.logger.info "Found #{resources.length()} resources"
+
+      resources.each do |resource|
+        public_id = resource["public_id"]
+        if public_id.include? "/"
+          Rails.logger.info "Skipping resource with id #{public_id}. It appears to be in a folder."
+          next
+        end
+        unless Image.find_by(public_id: public_id)
+          Rails.logger.info "Soft-deleting #{public_id}"
+          Cloudinary::Uploader.rename(public_id, "#{SOFT_DELETE_FOLDER}/#{public_id}")
+        end
+      end
+
+      break unless next_cursor
+    end
+  end
+
+  desc "Empties SOFT_DELETED_FOLDER, thus hard-deleting all the images within."
+  task empty_soft_deleted: [:environment] do
+    next_cursor = nil
+    while true do
+      results = Cloudinary::Api.resources(type: "upload", prefix: SOFT_DELETE_FOLDER, next_cursor: next_cursor)
+      next_cursor = results.fetch("next_cursor", nil)
+      resources = results["resources"]
+      Rails.logger.info "Starting to hard-delete #{resources.length()} resources"
+
+      resources.each do |resource|
+        public_id = resource["public_id"]
+        Rails.logger.info "Destroying #{public_id}"
+        Cloudinary::Uploader.destroy(public_id)
+      end
+      break unless next_cursor
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,6 +23,11 @@ Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+# Load Rake tasks once, so that they are available in specs. If you call
+# load_tasks again, they will be re-added to the task list, and when you invoke
+# a task once it will get run twice (or as many times as it has been "loaded").
+Rails.application.load_tasks
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/support/rake_helpers.rb
+++ b/spec/support/rake_helpers.rb
@@ -1,0 +1,13 @@
+module RakeHelpers
+  # Helpers for Rake tests
+
+  # Runs the provided rake task.
+  # @name [String] Name of the task to run, including namespace, e.g. "db:seed"
+  def self.run_task(name)
+    Rake::Task[name].invoke
+    # Because 'invoke' only executes a task once, subsequent calls to invoke for
+    # the same task do nothing. This is undesirable for testing, so we manually
+    # re-enable a task after invoking it.
+    Rake::Task[name].reenable
+  end
+end

--- a/spec/tasks/dummy_spec.rb
+++ b/spec/tasks/dummy_spec.rb
@@ -1,22 +1,11 @@
+require "./spec/support/rake_helpers"
 require "rails_helper"
 
 RSpec.describe "dummy.rake" do
-  before :all do
-    Rails.application.load_tasks
-  end
-
-  def run_task(name)
-    Rake::Task[name].invoke
-    # Because 'invoke' only executes a task once, subsequent calls to invoke for
-    # the same task do nothing. This is undesirable for testing, so we manually
-    # re-enable a task after invoking it.
-    Rake::Task[name].reenable
-  end
-
   describe "dummy:admin" do
     it "creates an admin user" do
       expect {
-        run_task("dummy:admin")
+        RakeHelpers.run_task("dummy:admin")
       }.to change { User.where(admin: true).count }.by(1)
     end
   end
@@ -24,7 +13,7 @@ RSpec.describe "dummy.rake" do
   describe "dummy:users" do
     it "creates 10 users" do
       expect {
-        run_task("dummy:users")
+        RakeHelpers.run_task("dummy:users")
       }.to change { User.count }.by(10)
     end
   end
@@ -32,7 +21,7 @@ RSpec.describe "dummy.rake" do
   describe "dummy:artist_pages" do
     it "creates 5 artist_pages" do
       expect {
-        run_task("dummy:artist_pages")
+        RakeHelpers.run_task("dummy:artist_pages")
       }.to change { ArtistPage.count }.by(5)
     end
   end
@@ -40,13 +29,13 @@ RSpec.describe "dummy.rake" do
   describe "dummy:posts" do
     before do
       # Create some artist pages with owners to create posts for
-      run_task("dummy:users")
-      run_task("dummy:artist_pages")
+      RakeHelpers.run_task("dummy:users")
+      RakeHelpers.run_task("dummy:artist_pages")
     end
 
     it "creates some posts" do
       post_count_before = Post.count
-      run_task("dummy:posts")
+      RakeHelpers.run_task("dummy:posts")
       expect(Post.count).to be > post_count_before
     end
   end

--- a/spec/tasks/images_spec.rb
+++ b/spec/tasks/images_spec.rb
@@ -1,0 +1,105 @@
+require "./spec/support/rake_helpers"
+require "rails_helper"
+
+# Tasks to help manage images stored in Cloudinary.
+# To run on Heroku:
+# $ heroku run rake images:soft_delete_unused --app <ampled-web | ampled-web-prod>
+
+RSpec.describe "images.rake" do
+  describe "images:soft_delete_unused" do
+    let(:task) { "images:soft_delete_unused" }
+
+    # Scaffolding for fake Cloudinary API response.
+    # Public id array will be filled by each test context.
+    let(:cloudinary_public_ids) { [] }
+    let(:cloudinary_result) do
+      {
+        "resources" => cloudinary_public_ids.map { |id| { "public_id" => id } }
+      }
+    end
+
+    before :each do
+      allow(Cloudinary::Api).to receive(:resources).and_return(cloudinary_result)
+      allow(Cloudinary::Uploader).to receive(:rename)
+    end
+
+    context "when an image is in Cloudinary but not in the database" do
+      let(:cloudinary_public_ids) { ["extremely_unused_id"] }
+
+      it "is soft-deleted" do
+        RakeHelpers.run_task(task)
+        expect(Cloudinary::Uploader).to have_received(:rename)
+          .with("extremely_unused_id", "soft_deleted/extremely_unused_id")
+      end
+    end
+
+    context "when an image is in Cloudinary and in the database" do
+      let(:image) { create(:image) }
+      let(:cloudinary_public_ids) { [image.public_id] }
+
+      it "skips the image without soft-deleting it" do
+        expect(Cloudinary::Uploader).to_not receive(:rename)
+        RakeHelpers.run_task(task)
+      end
+    end
+
+    context "when there are multiple pages of Cloudinary resources" do
+      let(:images_first_page) { create_list(:image, 5) }
+      let(:deletable_image_ids) { %w[fake_id_1 fake_id_2] }
+      let(:cloudinary_first_result) do
+        {
+          "resources" => images_first_page.map { |img| { "public_id" => img.public_id } },
+          "next_cursor" => "fake_cursor_for_next_page"
+        }
+      end
+      let(:cloudinary_second_result) do
+        {
+          "resources" => deletable_image_ids.map { |id| { "public_id" => id } }
+        }
+      end
+
+      before do
+        allow(Cloudinary::Api).to receive(:resources).and_return(cloudinary_first_result, cloudinary_second_result)
+      end
+
+      it "processes all the pages" do
+        RakeHelpers.run_task(task)
+        expect(Cloudinary::Api).to have_received(:resources).twice
+        expect(Cloudinary::Uploader).to have_received(:rename).exactly(deletable_image_ids.length).times
+      end
+    end
+  end
+
+  describe "images:empty_soft_deleted" do
+    let(:task) { "images:empty_soft_deleted" }
+
+    let(:cloudinary_result_1) do
+      {
+        "resources" => [{ "public_id" => "id1" }, { "public_id" => "id2" }],
+        "next_cursor" => "some_cursor_thingie"
+      }
+    end
+
+    let(:cloudinary_result_2) do
+      {
+        "resources" => [{ "public_id" => "id3" }, { "public_id" => "id4" }]
+      }
+    end
+
+    before :each do
+      allow(Cloudinary::Api).to receive(:resources).and_return(cloudinary_result_1, cloudinary_result_2)
+      allow(Cloudinary::Uploader).to receive(:destroy)
+    end
+
+    it "requests resources with the SOFT_DELETED_FOLDER prefix" do
+      RakeHelpers.run_task(task)
+      expect(Cloudinary::Api).to have_received(:resources).with(hash_including(prefix: "soft_deleted")).twice
+    end
+
+    it "paginates through results and destroys all the resources it finds" do
+      RakeHelpers.run_task(task)
+      expect(Cloudinary::Api).to have_received(:resources).twice
+      expect(Cloudinary::Uploader).to have_received(:destroy).exactly(4).times
+    end
+  end
+end


### PR DESCRIPTION
This PR adds two Rake tasks to be run manually as one-off maintenance tasks on production or acceptance. The tasks are as follows:
* `images:soft_delete_unused`: soft-deletes images whose `public_id` can't be found in the database; images are moved into a special soft-delete folder; images can be un-deleted by moving them back into the root folder
* `images:empty_soft_deleted`: destroys all images in the soft-delete folder; images can no longer be un-deleted after this

My plan is to proceed with the task of deleting all unused images from cloudinary by first running the soft-delete task. Then I'll wait a little bit (a week?) to make sure that I didn't soft-delete anything that was, in fact, used. If no alarms are raised, I will then run the `empty_soft_deleted` task to clear up Cloudinary space.

Trello: https://trello.com/c/a9XFUA9f/664-delete-all-unused-images-from-cloudinary
