### PR TITLE
Remove codecov integration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,0 @@
-codecov:
-  token: 9e841483-f7df-49c3-ae56-83ff79946ca0
-ignore:
-  - "lib/tasks/**"
-  - "config/**"
-  - "spec/**""

--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,6 @@ group :test do
   gem "capybara"
   # gem "capybara-email"
   gem "chromedriver-helper"
-  gem "codecov", require: false
   gem "selenium-webdriver"
   gem "simplecov"
   gem "vcr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -776,9 +776,6 @@ GEM
     cloudinary (1.9.1)
       aws_cf_signer
       rest-client
-    codecov (0.2.11)
-      json
-      simplecov
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -1126,7 +1123,6 @@ DEPENDENCIES
   capybara
   chromedriver-helper
   cloudinary
-  codecov
   coffee-rails
   devise
   devise-jwt

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Generated with [Raygun](https://github.com/carbonfive/raygun).
     - [Code Style](#code-style)
   - [Additional/Optional Development Details](#additionaloptional-development-details)
     - [Backup/Restore Database](#backuprestore-database)
-    - [Code Coverage (local)](#code-coverage-local)
+    - [Code Coverage](#code-coverage)
     - [Using Guard](#using-guard)
     - [Using Mailcatcher](#using-mailcatcher)
     - [Using ChromeDriver](#using-chromedriver)
@@ -158,13 +158,14 @@ The backup files are stored in `/db/backups/` directory. If you use zsh, your ra
 
 IMPORTANT: These commands will connect to whatever DB your rails environment is configured with.
 
-### Code Coverage (local)
+### Code Coverage
 
-Coverage for the ruby specs:
+To compute code coverage for the Ruby specs, set the `COVERAGE` env variable:
 
     $ COVERAGE=true rspec
 
-Code coverage is reported to Code Climate on every CI build so there's a record of trending.
+SimpleCov will output the coverage information into the `coverage/` directory. Open `coverage/index.html` to browse the
+coverage results.
 
 ### Using Guard
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,17 @@
 # Coverage must be enabled before the application is loaded.
 if ENV["COVERAGE"]
   require "simplecov"
-  require "codecov"
 
   SimpleCov.start do
     add_filter "/spec/"
     add_filter "/config/"
     add_filter "/vendor/"
+    add_filter "/tasks/"
     add_group  "Models", "app/models"
     add_group  "Controllers", "app/controllers"
     add_group  "Helpers", "app/helpers"
     add_group  "Views", "app/views"
     add_group  "Mailers", "app/mailers"
-    formatter SimpleCov::Formatter::Codecov
   end
 end
 


### PR DESCRIPTION
This PR also excludes `/tasks/` (the Rake tasks directory) from SimpleCov's coverage computations, and updates the README with details about where to find SimpleCov's coverage information.

Trello: https://trello.com/c/uDr5WsXW/663-remove-codecov-integration-from-repo-to-avoid-getting-charged
