### PR TITLE
Remove obsolete sample_data from `setup`, add dummy data tasks instead

### DIFF
--- a/bin/reset-acceptance-with-sample-data.sh
+++ b/bin/reset-acceptance-with-sample-data.sh
@@ -2,7 +2,7 @@
 cwd=`dirname "$0"`
 source "$cwd/reset-config.cfg"
 
-echo "Loading sample_data on acceptance (destructive)..."
+echo "Loading sample data on acceptance (destructive)..."
 sleep 3
 
 set -x

--- a/bin/setup
+++ b/bin/setup
@@ -25,7 +25,7 @@ chdir APP_ROOT do
 
   puts "\n== Preparing database =="
   system! "bin/rails db:create:all"
-  system! "bin/rails db:setup db:sample_data"
+  system! "bin/rails db:setup dummy:admin dummy:users dummy:artist_pages dummy:posts"
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"


### PR DESCRIPTION
Small fix to the `bin/setup` script, which I left pointing at now-deleted `sample_task` by mistake.

Thanks @selftext for catching this!