### PR TITLE
709: Create time bank data models

### DIFF
--- a/app/controllers/admin/contributor_time_controller.rb
+++ b/app/controllers/admin/contributor_time_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class ContributorTimeController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = ContributorTime.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   ContributorTime.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/contributors_controller.rb
+++ b/app/controllers/admin/contributors_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class ContributorsController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = Contributor.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   Contributor.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/contributor_dashboard.rb
+++ b/app/dashboards/contributor_dashboard.rb
@@ -1,0 +1,65 @@
+require "administrate/base_dashboard"
+
+class ContributorDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    user: Field::BelongsTo.with_options(
+      order: 'email',
+      searchable: true,
+      searchable_field: 'email',
+    ),
+    id: Field::Number,
+    joined_on: Field::DateTime,
+    worker_owner_on: Field::DateTime,
+    inactive_on: Field::DateTime,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :user,
+    :id,
+    :joined_on,
+    :worker_owner_on,
+    :inactive_on
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :user,
+    :id,
+    :joined_on,
+    :worker_owner_on,
+    :inactive_on,
+    :created_at,
+    :updated_at,
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :user,
+    :joined_on,
+    :worker_owner_on,
+    :inactive_on,
+  ].freeze
+
+  # Overwrite this method to customize how contributors are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(contributor)
+    contributor.user.email
+  end
+end

--- a/app/dashboards/contributor_time_dashboard.rb
+++ b/app/dashboards/contributor_time_dashboard.rb
@@ -1,0 +1,64 @@
+require "administrate/base_dashboard"
+
+class ContributorTimeDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    contributor: Field::BelongsTo,
+    id: Field::Number,
+    started_on: Field::DateTime,
+    ended_on: Field::DateTime,
+    hours: Field::Number.with_options(decimals: 2),
+    notes: Field::Text,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :contributor,
+    :id,
+    :started_on,
+    :ended_on,
+    :hours,
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :contributor,
+    :id,
+    :started_on,
+    :ended_on,
+    :hours,
+    :notes,
+    :created_at,
+    :updated_at,
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :contributor,
+    :started_on,
+    :ended_on,
+    :hours,
+    :notes,
+  ].freeze
+
+  # Overwrite this method to customize how contributor time are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(contributor_time)
+  #   "ContributorTime ##{contributor_time.id}"
+  # end
+end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: contributors
+#
+#  created_at      :datetime         not null
+#  id              :bigint(8)        not null, primary key
+#  inactive_on     :date
+#  joined_on       :date
+#  updated_at      :datetime         not null
+#  user_id         :bigint(8)
+#  worker_owner_on :date
+#
+# Indexes
+#
+#  index_contributors_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+
+class Contributor < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/contributor_time.rb
+++ b/app/models/contributor_time.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: contributor_time
+#
+#  contributor_id :bigint(8)
+#  created_at     :datetime         not null
+#  ended_on       :date
+#  hours          :float
+#  id             :bigint(8)        not null, primary key
+#  notes          :text
+#  started_on     :date
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_contributor_time_on_contributor_id  (contributor_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (contributor_id => contributors.id)
+#
+
+class ContributorTime < ApplicationRecord
+  belongs_to :contributor
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.uncountable 'contributor_time'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
     resources :comments
     resources :plans
     resources :page_ownerships
+    resources :contributors
+    resources :contributor_time
 
     root to: "users#index"
   end

--- a/db/migrate/20201128100841_create_contributors.rb
+++ b/db/migrate/20201128100841_create_contributors.rb
@@ -1,0 +1,12 @@
+class CreateContributors < ActiveRecord::Migration[5.2]
+  def change
+    create_table :contributors do |t|
+      t.references :user, foreign_key: true
+      t.date :joined_on
+      t.date :worker_owner_on
+      t.date :inactive_on
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201129095835_create_contributor_time.rb
+++ b/db/migrate/20201129095835_create_contributor_time.rb
@@ -1,0 +1,13 @@
+class CreateContributorTime < ActiveRecord::Migration[5.2]
+  def change
+    create_table :contributor_time do |t|
+      t.references :contributor, foreign_key: true
+      t.date :started_on
+      t.date :ended_on
+      t.float :hours
+      t.text :notes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_26_212908) do
+ActiveRecord::Schema.define(version: 2020_11_29_095835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,27 @@ ActiveRecord::Schema.define(version: 2020_10_26_212908) do
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "contributor_time", force: :cascade do |t|
+    t.bigint "contributor_id"
+    t.date "started_on"
+    t.date "ended_on"
+    t.float "hours"
+    t.text "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contributor_id"], name: "index_contributor_time_on_contributor_id"
+  end
+
+  create_table "contributors", force: :cascade do |t|
+    t.bigint "user_id"
+    t.date "joined_on"
+    t.date "worker_owner_on"
+    t.date "inactive_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_contributors_on_user_id"
   end
 
   create_table "images", force: :cascade do |t|
@@ -169,6 +190,8 @@ ActiveRecord::Schema.define(version: 2020_10_26_212908) do
   add_foreign_key "audio_uploads", "posts"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
+  add_foreign_key "contributor_time", "contributors"
+  add_foreign_key "contributors", "users"
   add_foreign_key "plans", "artist_pages"
   add_foreign_key "posts", "artist_pages"
   add_foreign_key "posts", "users"

--- a/spec/factories/contributor_time.rb
+++ b/spec/factories/contributor_time.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: contributor_time
+#
+#  contributor_id :bigint(8)
+#  created_at     :datetime         not null
+#  ended_on       :date
+#  hours          :float
+#  id             :bigint(8)        not null, primary key
+#  notes          :text
+#  started_on     :date
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_contributor_time_on_contributor_id  (contributor_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (contributor_id => contributors.id)
+#
+
+FactoryBot.define do
+  factory :contributor_time do
+    contributor
+    started_on { "2020-10-18" }
+    ended_on { "2020-10-24" }
+    hours { 1.5 }
+    notes { "MyText" }
+  end
+end

--- a/spec/factories/contributors.rb
+++ b/spec/factories/contributors.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: contributors
+#
+#  created_at      :datetime         not null
+#  id              :bigint(8)        not null, primary key
+#  inactive_on     :date
+#  joined_on       :date
+#  updated_at      :datetime         not null
+#  user_id         :bigint(8)
+#  worker_owner_on :date
+#
+# Indexes
+#
+#  index_contributors_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+
+FactoryBot.define do
+  factory :contributor do
+    user
+    joined_on { "2020-01-14" }
+    worker_owner_on { "2020-08-20" }
+    inactive_on { "2020-10-14" }
+  end
+end

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe Contributor, type: :model do
+  it "is not valid without a user" do
+    contributor = Contributor.new(user: nil)
+    expect(contributor).to_not be_valid
+  end
+end

--- a/spec/models/contributor_time_spec.rb
+++ b/spec/models/contributor_time_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe ContributorTime, type: :model do
+  it "is not valid without a contributor" do
+    contributor_time = ContributorTime.new(contributor: nil)
+    expect(contributor_time).to_not be_valid
+  end
+end


### PR DESCRIPTION
This PR adds two new data models to track contributors' work on the platform. Trello: https://trello.com/c/iJ1sfanf/709-create-new-data-models-and-run-database-migrations

The `contributor` model is keyed off `user`. It stores dates when the contributor joined, became a worker-owner, and became inactive.

The `contributor_time` model is keyed off `contributor`. It stores hours for a given week.

There are admin dashboards for each model (see screenshots below).

For now, new contributors will be added in the admin dashboard, but contributor time will be added via Typeform survey (and eventually via something built in-house, like a form on the site). See [the documentation](https://docs.google.com/document/d/1jvlhONbW663oOZQXax34supY7XOL-90cUe0Jb4AxtnU/edit#) for a full description of the project.

Here are some things to watch out for:

- I'm worried that, when adding a new contributor on the admin dashboard, the dropdown menu of user emails is too overwhelming. I've sorted the list alphabetically, but there are over a thousand users. One option I've seen is this gem https://github.com/fishbrain/administrate-field-belongs_to_search that enables type ahead search on the field, though I don't know how widely used this gem is. Something to consider.
- I added an inflections rule to keep `contributor_time` singular rather than plural. If this seems hacky, I'm open to considering other ways to go about this or other names for the model.
- I'd like the date field in `contributor_time` to be the start of the week (since weekly hours is our standard way of recording contributor time). We can handle this in a form input, but I don't know how to modify the administrate date picker to truncate to the week. Maybe this is fine since adding contributor time directly in the admin dashboard will be rare. But I'm open to other approaches.
- I didn't see any opportunities for tests here, but please let me know if I missed something.

Screenshot of Contributors admin dashboard:

<img width="1438" alt="Screen Shot 2020-10-21 at 6 10 49 AM" src="https://user-images.githubusercontent.com/1423853/96707667-2eefee00-1366-11eb-984c-4a8e5970b5a4.png">

Screenshot of Contributor Time admin dashboard:

<img width="1425" alt="Screen Shot 2020-10-21 at 6 11 05 AM" src="https://user-images.githubusercontent.com/1423853/96707707-3911ec80-1366-11eb-982d-13e21c99d823.png">
