### PR TITLE
[Bug] render Money correctly in emails

### DIFF
--- a/app/jobs/new_supporter_email_job.rb
+++ b/app/jobs/new_supporter_email_job.rb
@@ -22,8 +22,8 @@ class NewSupporterEmailJob
         template_model: {
           supporter_name: subscription.user.name,
           artist_name: artist.name,
-          support_amount: format("%.2f", subscription.plan.nominal_amount / 100.0),
-          total_artist_support_amount: format("%.2f", artist.monthly_total / 100.0)
+          support_amount: format("%.2f", subscription.plan.nominal_amount),
+          total_artist_support_amount: format("%.2f", artist.monthly_total)
         }
       }
     end

--- a/app/jobs/user_supported_artist_email_job.rb
+++ b/app/jobs/user_supported_artist_email_job.rb
@@ -23,7 +23,7 @@ class UserSupportedArtistEmailJob
           artist_page_link: "#{ENV["REACT_APP_API_URL"]}/artist/#{artist_page.slug}",
           promote_artist_page_link: "#{ENV["REACT_APP_API_URL"]}/artist/#{artist_page.slug}/promote",
           social_image_url: social_image[:url],
-          support_amount: format("%.2f", subscription.plan.nominal_amount / 100.0)
+          support_amount: format("%.2f", subscription.plan.nominal_amount)
         }
       }]
     )

--- a/spec/jobs/artist_paid_email_job_spec.rb
+++ b/spec/jobs/artist_paid_email_job_spec.rb
@@ -45,7 +45,7 @@ describe ArtistPaidEmailJob, type: :job do
           template_alias: "artist-paid",
           template_model: {
             artist_name: artist_page.name,
-            amount_paid: format("%.2f", amount_in_cents / 100.0),
+            amount_paid: "16.41",
             currency_name: currency.upcase,
             arrival_date_formatted: arrival_date_formatted
           }

--- a/spec/jobs/new_supporter_email_job_spec.rb
+++ b/spec/jobs/new_supporter_email_job_spec.rb
@@ -21,8 +21,8 @@ describe NewSupporterEmailJob, type: :job do
           template_model: {
             supporter_name: supporter.name,
             artist_name: artist.name,
-            support_amount: format("%.2f", subscription.plan.nominal_amount / 100.0),
-            total_artist_support_amount: format("%.2f", artist.monthly_total / 100.0)
+            support_amount: "5.00",
+            total_artist_support_amount: "5.00"
           }
         }
       ]

--- a/spec/jobs/user_supported_artist_email_job_spec.rb
+++ b/spec/jobs/user_supported_artist_email_job_spec.rb
@@ -31,7 +31,7 @@ describe UserSupportedArtistEmailJob, type: :job do
             artist_page_link: "#{ENV["REACT_APP_API_URL"]}/artist/#{artist_page.slug}",
             promote_artist_page_link: "#{ENV["REACT_APP_API_URL"]}/artist/#{artist_page.slug}/promote",
             social_image_url: social_image[:url],
-            support_amount: format("%.2f", subscription.plan.nominal_amount / 100.0)
+            support_amount: "5.00"
           }
         }
       ]
@@ -60,7 +60,7 @@ describe UserSupportedArtistEmailJob, type: :job do
             artist_page_link: "#{ENV["REACT_APP_API_URL"]}/artist/#{artist_page.slug}",
             promote_artist_page_link: "#{ENV["REACT_APP_API_URL"]}/artist/#{artist_page.slug}/promote",
             social_image_url: social_image[:url],
-            support_amount: format("%.2f", subscription.plan.nominal_amount / 100.0)
+            support_amount: "5.00"
           }
         }
       ]


### PR DESCRIPTION
We noticed in acceptance that due to a recent change money amounts in some emails were not getting rendered correctly. This fixes that issue (stops dividing values by 100) and updates tests to make it more difficult for this to happen again.