### PR TITLE
return correct monthly_total in me/index JBuilder

### DIFF
--- a/app/models/artist_page.rb
+++ b/app/models/artist_page.rb
@@ -141,7 +141,7 @@ class ArtistPage < ApplicationRecord
   end
 
   def monthly_total
-    subscriptions.active.includes(:plan).reduce(0) do |sum, subscription|
+    subscriptions.active.includes(:plan).reduce(Money.zero("usd")) do |sum, subscription|
       sum + subscription.plan.nominal_amount
     end
   end

--- a/app/views/me/index.json.jbuilder
+++ b/app/views/me/index.json.jbuilder
@@ -59,7 +59,7 @@ json.ownedPages @owned_pages do |page|
   json.name page.page.name
   json.image page.page.cover_public_id
   json.supportersCount page.page.subscriber_count
-  json.monthlyTotal page.page.monthly_total
+  json.monthlyTotal page.page.monthly_total.fractional
   json.lastPost page.page.last_post_date
   json.lastPayout page.page.last_payout
   json.stripeSignup page.role == "admin" ? page.page.stripe_signup_url : json.null

--- a/spec/requests/me_controller_spec.rb
+++ b/spec/requests/me_controller_spec.rb
@@ -76,5 +76,45 @@ RSpec.describe MeController, type: :request do
         }
       ])
     end
+
+    it "returns ownedPages" do
+      artist_page = create(:artist_page)
+      artist_page.owners << user
+
+      plan = create(:plan, artist_page: artist_page, nominal_amount: 1758, currency: "usd")
+      create(
+        :subscription,
+        artist_page: artist_page,
+        plan: plan,
+        created_at: Time.new(2020, 10, 29, 14, 30, 23, "+00:00")
+      )
+
+      get url
+
+      expect(JSON.parse(response.body)["ownedPages"]).to eq(
+        [
+          {
+            "approved" => false,
+            "artistColor" => nil,
+            "artistId" => artist_page.id,
+            "artistSlug" => nil,
+            "image" => nil,
+            "instrument" => nil,
+            "isStripeSetup" => false,
+            "lastPayout" => nil,
+            "lastPost" => nil,
+            "monthlyTotal" => 1758,
+            "name" => artist_page.name,
+            "promoteSquareImages" => [nil, nil, nil, nil, nil, nil],
+            "promoteStoryImages" => [nil, nil, nil, nil, nil, nil, nil],
+            "role" => "member",
+            "stripeDashboard" => nil,
+            "stripeSignup" => nil,
+            "supporterImages" => [nil, nil],
+            "supportersCount" => 1
+          }
+        ]
+      )
+    end
   end
 end


### PR DESCRIPTION
Another Money amount fuck up. This time with MonthlyTotal :( 

Fix is fairly simple, just call `#fractional` on the Money amount to get it to return what it was doing before.

I've checked for other instances of methods that rely on `nominal_amount` getting called from a Jbuilder. Doesn't seem like there is any.