### PR TITLE
provide empty template_model to Postmark

### DIFF
--- a/app/mailers/artist_owner_status_mailer.rb
+++ b/app/mailers/artist_owner_status_mailer.rb
@@ -11,6 +11,7 @@ class ArtistOwnerStatusMailer < PostmarkMailer
   end
 
   def artist_eligible_for_ownership(artist_page)
+    self.template_model = {}
     mail to: artist_page.owners.pluck(:email)
   end
 end

--- a/spec/mailers/artist_owner_status_mailer_spec.rb
+++ b/spec/mailers/artist_owner_status_mailer_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe ArtistOwnerStatusMailer, type: :mailer do
   describe "#artist_eligible_for_ownership" do
     let(:mail) { ArtistOwnerStatusMailer.artist_eligible_for_ownership(artist_page) }
 
+    it "sets template correctly" do
+      expect(mail.message.template_model).to eq({})
+    end
+
     it "sets addresses correctly" do
       expect(mail.message.to).to eq(["garfield@cbs.com", "bigglesworth@evil.co"])
       expect(mail.message.from).to eq([ENV["POSTMARK_FROM_EMAIL"]].compact)


### PR DESCRIPTION
[Apparently](https://sentry.io/organizations/ampled/issues/2003027413/?referrer=slack), you [need to provide Postmark with a template_model](https://postmarkapp.com/developer/api/templates-api), even when your template is empty. It would be nice if the postmark-rails gem didn't [cover this up](https://github.com/wildbit/postmark-rails/blob/f1ae4f17dfe575fb2ff0404c4d09cead86460f82/lib/postmark-rails/templated_mailer.rb#L53) in development (perhaps I will find the time to be the change I want to see in the world). This sets the template to empty for the `artist_eligible_for_ownership` email.