### PR TITLE
(694) send Stripe anomalies to Sentry

### DIFF
--- a/app/services/stripe_reconciliation/anomaly_notifier.rb
+++ b/app/services/stripe_reconciliation/anomaly_notifier.rb
@@ -1,4 +1,6 @@
 module StripeReconciliation
+  class AnomalyDetectedException < StandardError; end
+
   class AnomalyNotifier
     def initialize(anomaly:, stripe_object:)
       @anomaly = anomaly
@@ -15,6 +17,7 @@ module StripeReconciliation
       }
 
       Rails.logger.info("[#{self.class.name}] Anomaly detected #{log_fields}")
+      Raven.capture_exception(AnomalyDetectedException.new, extra: log_fields)
     end
   end
 end

--- a/spec/services/stripe_reconciliation/anomaly_notifier_spec.rb
+++ b/spec/services/stripe_reconciliation/anomaly_notifier_spec.rb
@@ -10,15 +10,27 @@ module StripeReconciliation
           id: "in_1036Vr2eZvKYlo2CfjuUHA94"
         )
       end
+      let(:notifier) { described_class.new(anomaly: anomaly, stripe_object: stripe_object) }
 
       it "logs anomaly and Stripe details" do
-        notifier = described_class.new(anomaly: anomaly, stripe_object: stripe_object)
         expected_log_message = "[StripeReconciliation::AnomalyNotifier] Anomaly detected " \
           "{:stripe_object_type=>\"invoice\", :stripe_object_id=>\"in_1036Vr2eZvKYlo2CfjuUHA94\", " \
           ":anomaly=>:unexpected_currency}"
 
         expect(Rails.logger).to receive(:info).with(expected_log_message)
 
+        notifier.notify
+      end
+
+      it "calls Raven.capture_exception with an AnomalyDetectedException" do
+        expect(Raven).to receive(:capture_exception).with(
+          kind_of(AnomalyDetectedException),
+          extra: {
+            stripe_object_type: "invoice",
+            stripe_object_id: "in_1036Vr2eZvKYlo2CfjuUHA94",
+            anomaly: :unexpected_currency
+          }
+        )
         notifier.notify
       end
     end


### PR DESCRIPTION
Trello: - https://trello.com/c/es2hwrAF/694-stripe-reconciliation

I've been spot checking the logs and Stripe reconciliation seems to be succeeding/correct. Now if there is a problem we should send it to Sentry via Raven. This updates the `StripeReconciliation::AnomalyNotifier` to do that.  