### PR TITLE
Add ChargeReconciler; alert if we encounter refunded Stripe Charge.

### DIFF
--- a/app/jobs/stripe_reconciliation/reconcile_stripe_object_job.rb
+++ b/app/jobs/stripe_reconciliation/reconcile_stripe_object_job.rb
@@ -6,10 +6,12 @@ module StripeReconciliation
     def perform(stripe_object_hash)
       stripe_object = Stripe::Util.convert_to_stripe_object(stripe_object_hash.symbolize_keys)
       reconciler_class = case stripe_object
+                         when Stripe::Charge
+                           ChargeReconciler
                          when Stripe::Invoice
                            InvoiceReconciler
                          else
-                           log_info("not reconciling Stipe object type #{stripe_object.object}")
+                           log_info("not reconciling Stripe object type #{stripe_object.object}")
                            return
                          end
 

--- a/app/lib/stripe_util.rb
+++ b/app/lib/stripe_util.rb
@@ -15,6 +15,13 @@ module StripeUtil
   # to be the after-fee amount (not including Ampled's platform fee).
   # We are charged 2.9% + 30 cents for USD transacitions
   #
+  # Example:
+  #   Nominal amount: $5.00
+  #   Fees: $1.18
+  #     Stripe fee: $0.46 (2.9% + $0.30)
+  #     Ampled fee: $0.72 (13.24%)
+  #   Charge amount: $5.46
+  #
   # @param nominal_amount [Money] Nominal amount
   # @return [Money] Calculated charge amount
   # @raise [StandardError] Raised if the `nominal_amount` currency is not USD

--- a/app/services/stripe_reconciliation/charge_reconciler.rb
+++ b/app/services/stripe_reconciliation/charge_reconciler.rb
@@ -1,0 +1,20 @@
+module StripeReconciliation
+  class ChargeReconciler
+    attr_reader :anomaly
+
+    # @param stripe_charge [Stripe::Charge]
+    def initialize(stripe_charge)
+      @stripe_charge = stripe_charge
+    end
+
+    # @return [Boolean] Returns `false` if an anomaly is detected, `true` otherwise.
+    def reconcile
+      if @stripe_charge.refunded
+        @anomaly = :charge_refunded
+        return false
+      end
+
+      true
+    end
+  end
+end

--- a/spec/jobs/stripe_reconciliation/reconcile_stripe_object_job_spec.rb
+++ b/spec/jobs/stripe_reconciliation/reconcile_stripe_object_job_spec.rb
@@ -3,37 +3,54 @@ require "rails_helper"
 module StripeReconciliation
   describe ReconcileStripeObjectJob, type: :job do
     describe "#perform" do
-      let!(:stripe_object) do
+      let(:stripe_invoice_hash) do
         { "object" => "invoice" }
       end
 
+      let(:stripe_charge_hash) do
+        { "object" => "charge" }
+      end
+
       it "reconciles an invoice with InvoiceReconciler" do
-        expect(InvoiceReconciler).to receive(:new).with(Stripe::Invoice.construct_from(stripe_object)).and_return(
+        expect(InvoiceReconciler).to receive(:new).with(Stripe::Invoice.construct_from(stripe_invoice_hash)).and_return(
           instance_double("InvoiceReconciler", reconcile: true)
         )
 
         expect(AnomalyNotifier).to receive(:new).never
 
-        described_class.new.perform(stripe_object)
+        described_class.new.perform(stripe_invoice_hash)
+      end
+
+      it "reconciles a charge with ChargeReconciler" do
+        expect(ChargeReconciler).to receive(:new).with(Stripe::Charge.construct_from(stripe_charge_hash)).and_return(
+          instance_double("ChargeReconciler", reconcile: true)
+        )
+
+        expect(AnomalyNotifier).to receive(:new).never
+
+        described_class.new.perform(stripe_charge_hash)
       end
 
       it "is silent when reconciling a Stripe object with an unknown type" do
-        stripe_object["object"] = "account"
+        unknown_stripe_object = { "object" => "foo" }
 
-        described_class.new.perform(stripe_object)
+        described_class.new.perform(unknown_stripe_object)
       end
 
       it "uses AnomalyNotifier when reconiliation fails" do
-        expect(InvoiceReconciler).to receive(:new).with(Stripe::Invoice.construct_from(stripe_object)).and_return(
+        expect(InvoiceReconciler).to receive(:new).with(Stripe::Invoice.construct_from(stripe_invoice_hash)).and_return(
           instance_double("InvoiceReconciler", reconcile: false, anomaly: :unexpected_currency)
         )
 
         expect(AnomalyNotifier).to receive(:new)
-          .with(anomaly: :unexpected_currency, stripe_object: Stripe::Invoice.construct_from(stripe_object)).and_return(
+          .with(
+            anomaly: :unexpected_currency,
+            stripe_object: Stripe::Invoice.construct_from(stripe_invoice_hash)
+          ).and_return(
             instance_double("AnomalyNotifier", notify: nil)
           )
 
-        described_class.new.perform(stripe_object)
+        described_class.new.perform(stripe_invoice_hash)
       end
     end
   end

--- a/spec/services/stripe_reconciliation/charge_reconciler_spec.rb
+++ b/spec/services/stripe_reconciliation/charge_reconciler_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+module StripeReconciliation
+  RSpec.describe ChargeReconciler, type: :service do
+    describe "#reconcile" do
+      let(:stripe_charge) do
+        Stripe::Charge.construct_from(
+          id: "ch_abc123",
+          refunded: false
+        )
+      end
+
+      describe "charge is normal" do
+        it "returns true and doesn't record an anomaly" do
+          reconciler = described_class.new(stripe_charge)
+
+          result = reconciler.reconcile
+
+          expect(result).to eq(true)
+          expect(reconciler.anomaly).to be(nil)
+        end
+      end
+
+      describe "charge is refunded" do
+        it "returns false and records an anomaly" do
+          stripe_charge.refunded = true
+          reconciler = described_class.new(stripe_charge)
+
+          result = reconciler.reconcile
+
+          expect(result).to eq(false)
+          expect(reconciler.anomaly).to be(:charge_refunded)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
@ryanquanz and I paired on this! As part of https://trello.com/c/es2hwrAF/694-stripe-reconciliation, we'll notify when we encounter a refunded Stripe Charge, which we don't currently handle.