### PR TITLE
stop sending Sentry anomalies in acceptance

### DIFF
--- a/app/services/stripe_reconciliation/anomaly_notifier.rb
+++ b/app/services/stripe_reconciliation/anomaly_notifier.rb
@@ -17,7 +17,7 @@ module StripeReconciliation
       }
 
       Rails.logger.info("[#{self.class.name}] Anomaly detected #{log_fields}")
-      Raven.capture_exception(AnomalyDetectedException.new, extra: log_fields)
+      Raven.capture_exception(AnomalyDetectedException.new, extra: log_fields) unless Rails.env.acceptance?
     end
   end
 end

--- a/spec/services/stripe_reconciliation/anomaly_notifier_spec.rb
+++ b/spec/services/stripe_reconciliation/anomaly_notifier_spec.rb
@@ -33,6 +33,17 @@ module StripeReconciliation
         )
         notifier.notify
       end
+
+      context "in acceptance" do
+        before(:each) do
+          allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("acceptance"))
+        end
+
+        it "does not call Raven.capture_exception" do
+          expect(Raven).not_to receive(:capture_exception)
+          notifier.notify
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This pretty straight forward. We don't want to send anomalies to Sentry in acceptance, there are a bunch of weird Stripe stuff we don't plan or have the time to fix.