### PR TITLE
722: filter to only active subscriptions

### DIFF
--- a/app/views/artist_pages/subscribers_csv.erb
+++ b/app/views/artist_pages/subscribers_csv.erb
@@ -1,5 +1,5 @@
 <%- headers = ['Name', 'Last Name', 'Email'] -%>
 <%= CSV.generate_line headers %>
-<%- @artist_page.subscribers.each do |subscriber| -%>
+<%- @artist_page.active_subscribers.each do |subscriber| -%>
 <%= CSV.generate_line([subscriber.name, subscriber.last_name, subscriber.email]) -%>
 <%- end -%>

--- a/spec/features/artist_page_spec.rb
+++ b/spec/features/artist_page_spec.rb
@@ -152,6 +152,11 @@ RSpec.describe ArtistPagesController, type: :request do
     let(:url) { "/artist/#{artist_page.slug}/subscribers_csv" }
     let!(:subscription) { create(:subscription, user: supporter, artist_page: artist_page) }
 
+    let(:ex_supporter) { create(:user, confirmed_at: Time.current) }
+    let!(:cancelled_subscription) do
+      create(:subscription, user: ex_supporter, artist_page: artist_page, status: :cancelled)
+    end
+
     context "when current user is not an admin" do
       it "returns a 403 forbidden error" do
         get url
@@ -179,6 +184,13 @@ RSpec.describe ArtistPagesController, type: :request do
         actual_csv = CSV.parse(response.body)
         expect(actual_csv).to include(["Name", "Last Name", "Email"])
         expect(actual_csv).to include([supporter.name, supporter.last_name, supporter.email])
+      end
+
+      it "returns csv without cancelled subscribers" do
+        get url
+        actual_csv = CSV.parse(response.body)
+        expect(actual_csv).to include(["Name", "Last Name", "Email"])
+        expect(actual_csv).to_not include([ex_supporter.name, ex_supporter.last_name, ex_supporter.email])
       end
     end
   end


### PR DESCRIPTION
Trello: - https://trello.com/c/4DxPAj9N/722-artist-subscriberscsv-api-including-cancelled-subscriptions

We were not filtering out cancelled subscriptions from this admin API. This PR is just applying the filter so that the CSV that gets generated only contains subscriptions scoped to `:active`. I can also rename the API route and subsequent methods to `active_subscribers_csv` if we want to be explicit.