### PR TITLE
721: Hide unapproved artist from google

### DIFF
--- a/client/src/containers/artist/Artist.tsx
+++ b/client/src/containers/artist/Artist.tsx
@@ -343,6 +343,9 @@ class ArtistComponent extends React.Component<Props, any> {
               {artist.name} | Ampled | Direct Community Support For Music
               Artists
             </title>
+            {!artist.approved && (
+              <meta name="robots" content="noindex, nofollow" />
+            )}
           </Helmet>
         )}
         {artist &&


### PR DESCRIPTION
Trello: - https://trello.com/c/xPJnS4PF/721-set-meta-tag-for-to-no-index-unapproved-pages
