### PR TITLE
724: Add web monetization meta tag to site base HTML

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -42,6 +42,10 @@
       name="twitter:site"
       content="@ampl3d"
     />
+    <meta
+      name="monetization"
+      content="$ilp.uphold.com/PKiih37iA6WX"
+    />
     <script src="https://js.stripe.com/v3/" async id="stripe-js"></script>
     <!--
       manifest.json provides metadata used when your web app is added to the


### PR DESCRIPTION
This adds a global meta tag with the web monetization wallet endpoint for Ampled.

Tested locally with the command-line [`is-web-monetized` tool](https://github.com/jkga/is-web-monetized):
![Screen Shot 2020-12-26 at 8 28 57 PM](https://user-images.githubusercontent.com/6729309/103163921-465db400-47b9-11eb-9eae-3f4d8ccb80da.png)

Trello: - https://trello.com/c/7iOx4M9G/724-add-web-monetization-support-to-ampled