### PR TITLE
fix postmark error

### DIFF
--- a/app/mailers/artist_owner_status_mailer.rb
+++ b/app/mailers/artist_owner_status_mailer.rb
@@ -11,7 +11,8 @@ class ArtistOwnerStatusMailer < PostmarkMailer
   end
 
   def artist_eligible_for_ownership(artist_page)
-    self.template_model = {}
+    # The Postmark Rails gem doesn't allow empty template models.
+    self.template_model = { "_unused_key": "" }
     mail to: artist_page.owners.pluck(:email)
   end
 end

--- a/spec/mailers/artist_owner_status_mailer_spec.rb
+++ b/spec/mailers/artist_owner_status_mailer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ArtistOwnerStatusMailer, type: :mailer do
     let(:mail) { ArtistOwnerStatusMailer.artist_eligible_for_ownership(artist_page) }
 
     it "sets template correctly" do
-      expect(mail.message.template_model).to eq({})
+      expect(mail.message.template_model).to eq({ "_unused_key": "" })
     end
 
     it "sets addresses correctly" do


### PR DESCRIPTION
sentry: https://sentry.io/organizations/ampled/issues/2003027413/?project=1834036&referrer=slack

This solution is ugly, but I think it is what the gem requires 🦑 Relevant GH issue: https://github.com/wildbit/postmark-rails/issues/71 .

tl;dr: The Postmark API doesn't require a template with keys be provided, but the Postmark gem does.