### PR TITLE
734: Fix browse page load more artist owners

### DIFF
--- a/client/src/containers/home/HomeBrowse.tsx
+++ b/client/src/containers/home/HomeBrowse.tsx
@@ -20,8 +20,7 @@ class HomeBrowse extends React.Component {
     width: window.innerWidth,
     loading: true,
     canLoadMore: true,
-    artistOwnersPage: 1,
-    artistsPage: 1,
+    page: 1,
     seed: Math.random(),
   };
 
@@ -31,7 +30,7 @@ class HomeBrowse extends React.Component {
   }
 
   componentDidMount() {
-    this.loadArtistOwners(this.state.artistOwnersPage);
+    this.loadArtistOwners(this.state.page);
     this.loadArtists();
     window.addEventListener('resize', this.updateDimensions);
   }
@@ -79,7 +78,7 @@ class HomeBrowse extends React.Component {
   };
 
   loadMoreArtistOwners = () => {
-    this.loadArtistOwners(+this.state.artistOwnersPage + 1);
+    this.loadArtistOwners(+this.state.page + 1);
   };
 
   getArtistSections = (artists) => {


### PR DESCRIPTION
Trello: - https://trello.com/c/wGVzGaxs/734-browse-page-on-load-more-the-second-time-around-it-just-loads-the-previous-8-artists
