### PR TITLE
Add recipients to artist page creation and approval emails

### DIFF
--- a/app/jobs/artist_page_approved_email_job.rb
+++ b/app/jobs/artist_page_approved_email_job.rb
@@ -20,6 +20,7 @@ class ArtistPageApprovedEmailJob
       {
         from: ENV["POSTMARK_FROM_EMAIL"],
         to: user.email,
+        bcc: "onboarding@ampled.com",
         template_alias: "artist-page-approved",
         template_model: {
           app_base_url: ENV["REACT_APP_API_URL"],

--- a/app/jobs/artist_page_create_email_job.rb
+++ b/app/jobs/artist_page_create_email_job.rb
@@ -13,7 +13,7 @@ class ArtistPageCreateEmailJob
       [{
         from: ENV["POSTMARK_FROM_EMAIL"],
         to: user.email,
-        bcc: ["austin@ampled.com", "collin@ampled.com"],
+        bcc: "onboarding@ampled.com",
         template_alias: "artist-page-created",
         template_model: {
           artist_name: artist.name

--- a/app/mailers/approval_request_mailer.rb
+++ b/app/mailers/approval_request_mailer.rb
@@ -11,7 +11,7 @@ class ApprovalRequestMailer < PostmarkMailer
       user_email: requesting_user.email
     }
 
-    mail to: "hello@ampled.com,austin@ampled.com"
+    mail to: "onboarding@ampled.com"
   end
 
   def artist_page_approval_requested_for_artists(artist_page, requesting_user)

--- a/spec/jobs/artist_page_approved_email_job_spec.rb
+++ b/spec/jobs/artist_page_approved_email_job_spec.rb
@@ -24,6 +24,7 @@ describe ArtistPageApprovedEmailJob, type: :job do
         {
           from: ENV["POSTMARK_FROM_EMAIL"],
           to: owner.email,
+          bcc: "onboarding@ampled.com",
           template_alias: "artist-page-approved",
           template_model: {
             app_base_url: ENV["REACT_APP_API_URL"],


### PR DESCRIPTION
This PR adds Ampled contributors as recipients to the following emails:

- approval_requested
- artist-page-created
- artist-page-approved

We could eventually have a common recipient list that we share across emails, but that can be a future iteration.

Trello: https://trello.com/c/33QuPeVX/748-add-recipients-to-new-artist-page-emails
