### PR TITLE
Upgrade gems to fix issues when running on AArch64

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -829,7 +829,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.9.25)
+    ffi (1.14.2)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.9)
@@ -1017,14 +1017,12 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (1.12.1)
-      ffi (~> 1.9.6)
-      sass (>= 3.3.0)
-    sassc-rails (1.3.0)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
       railties (>= 4.0.0)
-      sass
-      sassc (~> 1.9)
-      sprockets (> 2.11)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
       sprockets-rails
       tilt
     selectize-rails (0.12.6)


### PR DESCRIPTION
Prior to this pull request, this is what occurs when I run `bin/rails test`:

```
$ bin/rails test
/Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/ffi-1.9.25/lib/ffi/types.rb:69:in `find_type': unable to resolve type 'size_t' (TypeError)
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/ffi-1.9.25/lib/ffi/library.rb:585:in `find_type'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/ffi-1.9.25/lib/ffi/struct.rb:332:in `find_type'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/ffi-1.9.25/lib/ffi/struct.rb:326:in `find_field_type'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/ffi-1.9.25/lib/ffi/struct.rb:366:in `array_layout'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/ffi-1.9.25/lib/ffi/struct.rb:278:in `layout'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sassc-1.12.1/lib/sassc/native/sass_value.rb:51:in `<class:SassList>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sassc-1.12.1/lib/sassc/native/sass_value.rb:50:in `<module:Native>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sassc-1.12.1/lib/sassc/native/sass_value.rb:2:in `<module:SassC>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sassc-1.12.1/lib/sassc/native/sass_value.rb:1:in `<main>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/skylight-core-3.1.2/lib/skylight/core/probes.rb:119:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:287:in `block in require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:253:in `load_dependency'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:287:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:53:in `require_relative'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sassc-1.12.1/lib/sassc/native.rb:11:in `<module:Native>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sassc-1.12.1/lib/sassc/native.rb:4:in `<module:SassC>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sassc-1.12.1/lib/sassc/native.rb:3:in `<main>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/skylight-core-3.1.2/lib/skylight/core/probes.rb:119:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:287:in `block in require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:253:in `load_dependency'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:287:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:53:in `require_relative'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sassc-1.12.1/lib/sassc.rb:5:in `<main>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/skylight-core-3.1.2/lib/skylight/core/probes.rb:119:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:287:in `block in require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:253:in `load_dependency'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:287:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sassc-rails-1.3.0/lib/sassc/rails.rb:3:in `<main>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/skylight-core-3.1.2/lib/skylight/core/probes.rb:119:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:287:in `block in require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:253:in `load_dependency'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:287:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:53:in `require_relative'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/sassc-rails-1.3.0/lib/sassc-rails.rb:7:in `<main>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/runtime.rb:74:in `block (2 levels) in require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/runtime.rb:69:in `each'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/runtime.rb:69:in `block in require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/runtime.rb:58:in `each'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler/runtime.rb:58:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/2.7.0/bundler.rb:174:in `require'
	from /Users/coreyf/dev/ampled-music/ampled-web/config/application.rb:8:in `<top (required)>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/application.rb:92:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/application.rb:92:in `preload'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/application.rb:153:in `serve'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/application.rb:141:in `block in run'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/application.rb:135:in `loop'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/application.rb:135:in `run'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/application/boot.rb:19:in `<top (required)>'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
	from /Users/coreyf/.rbenv/versions/2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
	from -e:1:in `<main>'
```

The issue here is the version of the `ffi` gem we're frozen on [doesn't support AArch64](https://github.com/ffi/ffi/issues/841), which is the architecture the latest Macbook Air M1 uses. To get this working, I bumped the following gems:

* `sassc`
    * 1.12.1 → 2.4.0
    * https://github.com/sass/sassc-ruby/blob/master/CHANGELOG.md
* `sassc-rails`
    * 1.9.6 → 2.1.2
    * https://github.com/sass/sassc-rails#changelog
* `ffi`
    * 1.9.25 → 1.14.2
    * https://github.com/ffi/ffi/blob/master/CHANGELOG.md