### PR TITLE
Fix with_images scope so that it no longer returns duplicate rows.

### DIFF
--- a/app/models/artist_page.rb
+++ b/app/models/artist_page.rb
@@ -71,7 +71,7 @@ class ArtistPage < ApplicationRecord
 
   scope :approved, -> { where(approved: true) }
   scope :unapproved, -> { where(approved: false) }
-  scope :with_images, -> { left_outer_joins(:images).where.not(images: { id: nil }) }
+  scope :with_images, -> { includes(:images).where.not(images: { id: nil }) }
   scope :artist_owner, -> { where(artist_owner: true) }
   scope :exclude_community_page, -> { where.not(id: Rails.env.production? ? COMMUNITY_PAGE_ID : []) }
 

--- a/spec/models/artist_page_spec.rb
+++ b/spec/models/artist_page_spec.rb
@@ -31,10 +31,11 @@ RSpec.describe ArtistPage, type: :model do
   end
 
   describe ".with_images scope" do
-    let!(:page_with_images) { create(:artist_page, approved: true, images: [create(:image)]) }
+    let!(:page_with_images) { create(:artist_page, approved: true, images: create_list(:image, 3)) }
     let!(:sad_imageless_page) { create(:artist_page, approved: true) }
 
     it "returns page with images" do
+      expect(ArtistPage.with_images.count).to eq(1)
       expect(ArtistPage.with_images).to include(page_with_images)
     end
 


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/ampled-music/ampled-web/pull/728, which was causing the new `with_images` scope to return duplicate rows for pages with more than one image.

Trello: https://github.com/ampled-music/ampled-web/pull/new/fix-with-images-scope
