### PR TITLE
Add dependabot configuration, so that we might get automagic dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+# Ruby dependencies from / Gemfile
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+
+# Yarn dependencies in /client
+- package-ecosystem: npm
+  directory: "/client"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+
+# Yarn dependencies in / (used for build, scripts, etc)
+- package-ecosystem: npm
+  directory: "/client"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
This should help us keep more up-to-date, and to more easily fix issues when security advisories are issued.