### PR TITLE
Update autoprefixer-rails to version that is compatible with execjs 2.8.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,8 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.1)
-    autoprefixer-rails (9.5.1)
-      execjs
+    autoprefixer-rails (10.2.5.1)
+      execjs (> 0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
     aws-partitions (1.122.0)


### PR DESCRIPTION
This should fix the issue with asset precompilation we are seeing on deploys, which manifests as the following traceback upon calling `rake assets:precompile`:
```
rake aborted!
ExecJS::ProgramError: TypeError: Cannot read property 'version' of undefined
eval (eval at <anonymous> ((execjs):1:213), <anonymous>:1:10)
(execjs):1:213
(execjs):19:14
(execjs):1:40
Object.<anonymous> ((execjs):1:58)
Module._compile (internal/modules/cjs/loader.js:1063:30)
Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
Module.load (internal/modules/cjs/loader.js:928:32)
Function.Module._load (internal/modules/cjs/loader.js:769:14)
Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
/Users/anaulin/.gem/ruby/2.7.2/gems/execjs-2.8.1/lib/execjs/external_runtime.rb:39:in `exec'
/Users/anaulin/.gem/ruby/2.7.2/gems/execjs-2.8.1/lib/execjs/external_runtime.rb:21:in `eval'
/Users/anaulin/.gem/ruby/2.7.2/gems/execjs-2.8.1/lib/execjs/runtime.rb:64:in `eval'
/Users/anaulin/.gem/ruby/2.7.2/gems/autoprefixer-rails-9.5.1/lib/autoprefixer-rails/processor.rb:153:in `runtime'
/Users/anaulin/.gem/ruby/2.7.2/gems/autoprefixer-rails-9.5.1/lib/autoprefixer-rails/processor.rb:36:in `process'
/Users/anaulin/.gem/ruby/2.7.2/gems/autoprefixer-rails-9.5.1/lib/autoprefixer-rails/sprockets.rb:20:in `run'
/Users/anaulin/.gem/ruby/2.7.2/gems/autoprefixer-rails-9.5.1/lib/autoprefixer-rails/sprockets.rb:14:in `call'
[ SNIP ]
```

For details on the underlying bug, see: https://github.com/ai/autoprefixer-rails/issues/203