### PR TITLE
Configure Uglifier in harmony mode, to support ES6 syntax

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
This is an attempt to fix another issue with `bundle exec rake assets:precompile` that shows up only in production and not in development. This is a new Uglifier mode that must have been introduced by a recent version bump.