### PR TITLE
Tell Dependabot to ignore all major version upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 version: 2
 
+# Docs on available options:
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+
 updates:
   # Ruby dependencies from / Gemfile
   - package-ecosystem: bundler
@@ -7,6 +10,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: *
+        update-types: ["version-update:semver-major"]
 
   # Yarn dependencies in /client
   - package-ecosystem: npm
@@ -14,6 +20,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: *
+        update-types: ["version-update:semver-major"]
 
   # Yarn dependencies in / (used for build, scripts, etc)
   - package-ecosystem: npm
@@ -21,3 +30,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: *
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Based on the documentation [here](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore), this should make Dependabot ignore major version updates.

(Note that this PR is directly into `master`.)