### PR TITLE
fix video player import

### DIFF
--- a/client/src/containers/shared/video-modal/VideoModal.tsx
+++ b/client/src/containers/shared/video-modal/VideoModal.tsx
@@ -7,8 +7,8 @@ import IconButton from '@material-ui/core/IconButton';
 import Close from '../../../images/icons/Icon_Close-Cancel.svg';
 import { ReactSVG } from 'react-svg';
 
-import YouTubePlayer from 'react-player/lib/players/YouTube';
-import VimeoPlayer from 'react-player/lib/players/Vimeo';
+import YouTubePlayer from 'react-player/youtube';
+import VimeoPlayer from 'react-player/vimeo';
 
 import './video-modal.scss';
 import { theme } from './theme';


### PR DESCRIPTION
Videos weren't playing, just a white screen. This GH issue explains the problem: https://github.com/CookPete/react-player/issues/995.

Checked out locally, seems to work!

<img width="1552" alt="Screen Shot 2021-06-15 at 12 46 12 AM" src="https://user-images.githubusercontent.com/5213265/121994602-8f0f2680-cd73-11eb-8ab4-e070d6eb4c1a.png">
