### PR TITLE
set default application_fee_percent to 7

### DIFF
--- a/app/controllers/artist_pages_controller.rb
+++ b/app/controllers/artist_pages_controller.rb
@@ -93,7 +93,7 @@ class ArtistPagesController < ApplicationController
   def create
     # if we used activerecord validations, we could just check ArtistPage.new(...).valid?
     # and if not valid, return @artist_page.errors to give more info about whats wrong
-    unless (@artist_page = ArtistPage.create(artist_page_params))
+    unless (@artist_page = ArtistPage.create(default_artist_page_params.merge(artist_page_params)))
       return render json: { status: "error", message: "Something went wrong." }
     end
 
@@ -340,5 +340,9 @@ class ArtistPagesController < ApplicationController
     member_user.skip_confirmation_notification!
     member_user.save!
     member_user
+  end
+
+  def default_artist_page_params
+    { application_fee_percent: ArtistPage::DEFAULT_APPLICATION_FEE_PERCENT }
   end
 end

--- a/app/models/artist_page.rb
+++ b/app/models/artist_page.rb
@@ -40,6 +40,7 @@
 class ArtistPage < ApplicationRecord
   ARTIST_OWNER_THRESHOLD = 10
   COMMUNITY_PAGE_ID = 354
+  DEFAULT_APPLICATION_FEE_PERCENT = 7
 
   has_many :page_ownerships, dependent: :destroy
   has_many :owners, through: :page_ownerships, source: :user

--- a/spec/features/artist_page_spec.rb
+++ b/spec/features/artist_page_spec.rb
@@ -247,6 +247,50 @@ RSpec.describe ArtistPagesController, type: :request do
       end
     end
   end
+
+  describe "#create" do
+    let(:url) { "/artist_pages.json" }
+    let(:params) do
+      {
+        artist_page: {
+          name: "Kitteh' Rock",
+          slug: "kitteh",
+          bio: "A kitteh' who rocks",
+          location: "Litter box",
+          accent_color: "fuscia",
+          images_attributes: [{
+            "coordinates" => image.coordinates,
+            "url" => image.url,
+            "public_id" => image.public_id
+          }]
+        },
+        members: [{
+          email: "new@user.com",
+          firstName: "new",
+          lastName: "user"
+        }]
+      }
+    end
+
+    it "creates an artist page with expected params" do
+      post url, params: params
+
+      new_page = ArtistPage.find_by(**params[:artist_page].except(:images_attributes))
+
+      expect(response.status).to be 200
+      expect(new_page.application_fee_percent).to eq 7.0
+    end
+
+    it "creates an artist page with overriden application_fee_percent" do
+      artist_page_params = params[:artist_page].merge(application_fee_percent: 10)
+      post url, params: params.merge(artist_page: artist_page_params)
+
+      new_page = ArtistPage.find_by(**params[:artist_page].except(:images_attributes))
+
+      expect(response.status).to be 200
+      expect(new_page.application_fee_percent).to eq 10.0
+    end
+  end
 end
 
 RSpec.describe "PUT /artist_page", type: :request do


### PR DESCRIPTION
Per Austin we want to set all artist page application fee percentages to 7, this makes it so we set the percentage for all new artist pages.

This used to be done via a default value for for the application_fee_percent column on an artist page, now it will happen via a parameter passed in through the controller.

Follow up to remove the column default coming.