### PR TITLE
set application_fee_percent to 7 for everyone

### DIFF
--- a/db/migrate/20210625171139_update_all_artist_page_fees.rb
+++ b/db/migrate/20210625171139_update_all_artist_page_fees.rb
@@ -1,0 +1,7 @@
+class UpdateAllArtistPageFees < ActiveRecord::Migration[5.2]
+  def up
+    ArtistPage.pluck(:id).each do |artist_page_id|
+      UpdateApplicationFeePercentJob.perform_async(artist_page_id, 7)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_19_015523) do
+ActiveRecord::Schema.define(version: 2021_06_25_171139) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We want to set everyone's application_fee_percent to 7 before we launch PWF (so we no longer have to refund). this adds a migration to do the updates. Immediately before we turn on PWF we want to update everyone to 10.

This might delay some emails because it will backup the worker.