### PR TITLE
don't call set_screenshot before_save callback on ArtistPage unless video_url is changed

### DIFF
--- a/app/models/artist_page.rb
+++ b/app/models/artist_page.rb
@@ -68,7 +68,7 @@ class ArtistPage < ApplicationRecord
     less_than_or_equal_to: 100
   }
 
-  before_save :set_screenshot
+  before_save :set_screenshot, if: :will_save_change_to_video_url?
 
   before_save :check_approved
 


### PR DESCRIPTION
When we tried to set the application_fee_percent for every ArtistPage, we couldn't update some pages because the `set_screenshot` callback raised due to a deleted video. We don't need to fetch a new screenshot unless the video_url has changed. A better change may be to not do this via callback at all. 