### PR TITLE
reset application fees to 7 again

### DIFF
--- a/db/migrate/20210630232905_reset_application_fees_again.rb
+++ b/db/migrate/20210630232905_reset_application_fees_again.rb
@@ -1,0 +1,7 @@
+class ResetApplicationFeesAgain < ActiveRecord::Migration[5.2]
+  def up
+    ArtistPage.pluck(:id).each do |artist_page_id|
+      UpdateApplicationFeePercentJob.perform_async(artist_page_id, 7)
+    end
+  end
+end


### PR DESCRIPTION
we've been overcharging application fees because changes from https://github.com/ampled-music/ampled-web/pull/914 were lost in the main/development thing. this means we need to reset all application fees with Stripe back to 7