### PR TITLE
adding safe navigation operator to deeplink method

### DIFF
--- a/app/controllers/react_controller.rb
+++ b/app/controllers/react_controller.rb
@@ -37,7 +37,7 @@ class ReactController < ActionController::Base
 
   def deeplink
     post = Post.find_by(id: request[:post_id])
-    artist_page = post.artist_page
+    artist_page = post&.artist_page
     return render404 if artist_page.nil?
 
     response_html = render_to_string file: "public/index.html", layout: false


### PR DESCRIPTION
This is quick and simple fix for a NoMethod Error that happens occasionally in the react controller.

See Sentry log [here](https://sentry.io/organizations/ampled/issues/1908480371/?project=1834036&query=is%3Aunresolved) to see an example of the issue that this PR solves. 