### PR TITLE
Size image down and then make it retina display 2.0

### DIFF
--- a/client/src/containers/user-details/UserImage.tsx
+++ b/client/src/containers/user-details/UserImage.tsx
@@ -84,6 +84,8 @@ class UserImage extends React.Component<Props, any> {
               height={coordinates ? coordinates[3] : width}
               responsive_placeholder="blank"
             />
+            <Transformation width={width} crop="scale" />
+            <Transformation dpr="2.0" />
           </Image>
         ) : (
           <img


### PR DESCRIPTION
Noticed User images were coming in full scale and causing a lot of bandwidth for Cloudinary. 