### PR TITLE
fix /admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "zencoder"
 # Front-endy
 # Use uglifier for JavaScript compression.
 # This is only useful for things like the /admin/ engine, since this is an API-only server that serves no HTML/JS/CSS.
+gem "simple_form"
 gem "uglifier"
 # We still have .slim files. Unclear if they are still used, but requires more investigation.
 gem "slim-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1607,6 +1607,9 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    simple_form (5.1.0)
+      actionpack (>= 5.2)
+      activemodel (>= 5.2)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -1711,6 +1714,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven
   sidekiq
+  simple_form
   simplecov
   slim-rails
   stripe

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -19,7 +19,7 @@ By default, it renders:
   <meta name="ROBOTS" content="NOODP">
   <meta name="viewport" content="initial-scale=1">
   <title>
-    <%= content_for(:title) %> - <%= Rails.application.class.parent_name.titlecase %>
+    <%= content_for(:title) %> - <%= Rails.application.class.module_parent_name.titlecase %>
   </title>
   <%= render "stylesheet" %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Admin broke after the Rails 7 upgrade, as far as I can tell this should fix it!

`simple_form_for` was raising `NoMethodError` -- so I added the gem explicitly.

Also `parent_name` -> `module_parent_name`