### PR TITLE
return empty fragment if video url isnt legit

### DIFF
--- a/client/src/containers/artist/posts/post/Post.tsx
+++ b/client/src/containers/artist/posts/post/Post.tsx
@@ -177,6 +177,8 @@ const PostVideo = ({ videoUrl, doReflow }) => {
     VideoComponent = VimeoPlayer;
   } else if (isYouTube) {
     VideoComponent = YouTubePlayer;
+  } else {
+    return <></>;
   }
   return (
     <VideoComponent


### PR DESCRIPTION
This fixes https://www.ampled.com/artist/divorcecourt - their latest post is marked as video but has a video URL that is just their ampled URL, and we didn't have good fallback logic for that.