### PR TITLE
Payment Action Required

### DIFF
--- a/app/controllers/stripe_controller.rb
+++ b/app/controllers/stripe_controller.rb
@@ -55,6 +55,8 @@ class StripeController < ApplicationController
   # @param connect_account_id [String, nil] The Stripe Connect Account ID associated with the Stripe Event, if any
   def process_webhook(event_type, object, connect_account_id)
     case event_type
+    when "invoice.payment_action_required"
+      return invoice_payment_action_required(object)
     when "invoice.payment_failed"
       return invoice_payment_failed(object)
     when "invoice.payment_succeeded"
@@ -98,6 +100,17 @@ class StripeController < ApplicationController
     logger.info "Stripe: sending CardDeclineEmail to #{user.email}"
     CardDeclineEmailJob.perform_async(usersub.id)
     # TODO: update subscription to mark as failed?
+    render json: {}
+  end
+
+  # @param object [Stripe::Invoice]
+  def invoice_payment_action_required(object)
+    usersub = Subscription.find_by(stripe_id: object[:subscription])
+    user = User.find(usersub.user_id)
+
+    # send notification to user.email that their payment requires authentication
+    logger.info "Stripe: sending CardActionRequiredEmail to #{user.email}"
+    CardActionRequiredEmailJob.perform_async(usersub.id)
     render json: {}
   end
 

--- a/app/jobs/card_action_required_email_job.rb
+++ b/app/jobs/card_action_required_email_job.rb
@@ -1,0 +1,20 @@
+class CardActionRequiredEmailJob
+  include Sidekiq::Worker
+  attr_accessor :subscription
+
+  def perform(subscription_id)
+    @subscription = Subscription.find(subscription_id)
+    return if subscription.blank?
+
+    SendBatchEmail.call(
+      [{
+        from: ENV["POSTMARK_FROM_EMAIL"],
+        to: subscription.user.email,
+        template_alias: "credit_card_action_required",
+        template_model: {
+          artist: subscription.artist_page.name
+        }
+      }]
+    )
+  end
+end


### PR DESCRIPTION
For a lot of EU users payments have been failing because they need to enable the recurring payment from their bank. This would send an email as well as give them a notice of why its failing.